### PR TITLE
docs: add contributing guide and PR template, refine README

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,8 +16,6 @@ Closes #
 
 ## Validation
 
-Commands run in project CI order:
-
 - [ ] `npm run format:check`
 - [ ] `npm run lint`
 - [ ] `npm run typecheck`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,34 @@
+## Summary
+
+What changed, and why?
+
+## Related issue
+
+Closes #
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Refactor
+- [ ] Documentation
+- [ ] Test improvement
+
+## Validation
+
+Commands run in project CI order:
+
+- [ ] `npm run format:check`
+- [ ] `npm run lint`
+- [ ] `npm run typecheck`
+- [ ] `npm run knip`
+- [ ] `npm test`
+- [ ] `npm run build`
+
+## Checklist
+
+- [ ] PR targets `main`.
+- [ ] The change is linked to an issue, or an issue is not required.
+- [ ] The solution is minimal and intentional.
+- [ ] Tests were added or updated for behavior changes.
+- [ ] Documentation was updated where relevant.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,67 @@
+# Contributing
+
+This document defines how to contribute to `code-slicer`.
+
+## Workflow
+
+Use a simple flow: **Issue → PR to `main`**.
+
+1. Open or discuss an issue before non-trivial changes.
+2. Create a focused branch or fork.
+3. Open a PR to `main` and link the issue.
+
+Small fixes do not require an issue. Discuss larger changes before implementation.
+
+## Local setup and checks
+
+Requirements:
+
+- Node.js >= 22
+
+Run the same checks as CI, in this order:
+
+```bash
+npm ci
+npm run format:check
+npm run lint
+npm run typecheck
+npm run knip
+npm test
+npm run build
+```
+
+If you experience issues with `npm ci`:
+
+```bash
+npm run deps:reset
+```
+
+## Code expectations
+
+- Prefer minimal, intentional solutions over broad refactors.
+- Keep behavior deterministic and file-based.
+- Keep domain boundaries explicit.
+- Use clear names, small functions, and explicit interfaces.
+- Remove meaningful duplication without over-generalizing.
+- Add abstractions only when they solve recurring problems.
+- Add or update tests for behavior changes, including key edge cases.
+- Keep tests readable and focused on outcomes.
+
+## Commit style
+
+Use concise, conventional commit-style messages where practical:
+
+```text
+feat: add Vue SFC traversal
+fix: resolve extension fallback handling
+docs: add contributing guide
+```
+
+## Pull requests
+
+GitHub auto-loads the PR checklist from `.github/pull_request_template.md`.
+Complete that template when opening or updating a PR.
+
+## Review focus
+
+Maintainers review for correctness, simplicity, test quality, and alignment with project expectations.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ code-slicer src/entrypoint.ts
 
 ## Output format
 
-```
+```text
 relative/path/to/file.ts
 <source code>
 
@@ -86,32 +86,12 @@ Each file is printed as:
 - Minimal reproduction cases
 - Code review context extraction
 
-## Development
-
-```bash
-npm run dev
-npm run build
-npm run typecheck
-npm run lint
-npm run format
-```
-
 ## Contributing
 
-### Principles
+We welcome contributions.
 
-- Domain-Driven Design (DDD)
-- Clean Code:
-  - Small, focused functions
-  - Explicit naming
-  - No hidden side effects
-  - Clear separation of concerns
-
-### Expectations
-
-- Keep changes minimal and intentional
-- Avoid unnecessary abstractions
-- Preserve deterministic behavior
+Please read [`CONTRIBUTING.md`](CONTRIBUTING.md) for the source of truth on process, coding standards, and testing
+expectations.
 
 ## License
 


### PR DESCRIPTION
This pull request introduces important improvements to the project's contribution process and documentation. It adds a comprehensive contributing guide, a standardized pull request template, and updates the `README.md` to reference these new resources, ensuring contributors have clear guidelines to follow.

**Documentation and Contribution Process Improvements:**

* Added a detailed `CONTRIBUTING.md` guide outlining workflow, local setup, code expectations, commit style, and review focus for contributors.
* Introduced a standardized pull request template in `.github/pull_request_template.md` with sections for summary, related issue, type of change, validation steps, and a checklist to ensure quality and consistency.
* Updated `README.md` to point contributors to the new `CONTRIBUTING.md` as the authoritative source for contribution process and expectations, and removed outdated development and principles sections.

**Minor Documentation Fixes:**

* Improved code block formatting in the output format section of `README.md`.