### PR TITLE
feat(output): add selectable formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,8 +141,8 @@ code-slicer src/entrypoint.ts --format xml
 
 1. Detect file type (JavaScript, TypeScript, Vue)
 2. Parse source
-    - TypeScript AST for JS/TS/JSX/TSX
-    - Vue SFC parser for `.vue` files
+   - TypeScript AST for JS/TS/JSX/TSX
+   - Vue SFC parser for `.vue` files
 3. Extract imports (`import`, `export ... from`, `import()`)
 4. Resolve modules using TypeScript resolution with fallback logic
 5. Recursively traverse dependencies

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 
 Extract minimal, dependency-aware code context from an entry file for use in AI prompts.
 
-`code-slicer` is a CLI that traverses local imports from an entry file and outputs relevant code in dependency order.
-Built for AI workflows where precise context matters more than full repository dumps.
+`code-slicer` is a CLI that traverses local imports from an entry file and outputs relevant code in traversal order. It
+is designed for AI workflows where precise context matters more than full repository dumps.
 
 ## Quickstart
 
@@ -24,6 +24,10 @@ npm install --save-dev code-slicer
 code-slicer <entry-file>
 ```
 
+```bash
+code-slicer <entry-file> --format <plain|markdown|html|xml>
+```
+
 ### Example
 
 ```bash
@@ -35,11 +39,24 @@ code-slicer src/entrypoint.ts
 - Starts from a single entry file
 - Follows local imports and dependencies
 - Supports JavaScript, TypeScript, JSX, TSX, React, and Vue
-- Outputs files in dependency order
+- Outputs files in traversal order
 - Includes full source code for each file
 - Excludes external packages and unresolved modules
 
-## Output format
+## Output formats
+
+Supported formats:
+
+- `plain` (default)
+- `markdown`
+- `html`
+- `xml`
+
+### Plain (default)
+
+```bash
+code-slicer src/entrypoint.ts
+```
 
 ```text
 relative/path/to/file.ts
@@ -49,11 +66,64 @@ relative/path/to/another-file.ts
 <source code>
 ```
 
-Each file is printed as:
+### Markdown
 
-1. Relative path
-2. Source code
-3. Blank line
+```bash
+code-slicer src/entrypoint.ts --format markdown
+```
+
+````text
+### relative/path/to/file.ts
+
+```
+<source code>
+```
+
+### relative/path/to/another-file.ts
+
+```
+<source code>
+```
+````
+
+### HTML
+
+```bash
+code-slicer src/entrypoint.ts --format html
+```
+
+```text
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>code-slicer output</title>
+</head>
+<body>
+  <main class="code-slicer-output">
+    <section class="code-slicer-file">
+      <h3>relative/path/to/file.ts</h3>
+      <pre><code>&lt;source code&gt;</code></pre>
+    </section>
+  </main>
+</body>
+</html>
+```
+
+### XML
+
+```bash
+code-slicer src/entrypoint.ts --format xml
+```
+
+```text
+<?xml version="1.0" encoding="UTF-8"?>
+<files>
+  <file path="relative/path/to/file.ts">
+    <source>&lt;source code&gt;</source>
+  </file>
+</files>
+```
 
 ## Constraints
 
@@ -71,8 +141,8 @@ Each file is printed as:
 
 1. Detect file type (JavaScript, TypeScript, Vue)
 2. Parse source
-   - TypeScript AST for JS/TS/JSX/TSX
-   - Vue SFC parser for `.vue` files
+    - TypeScript AST for JS/TS/JSX/TSX
+    - Vue SFC parser for `.vue` files
 3. Extract imports (`import`, `export ... from`, `import()`)
 4. Resolve modules using TypeScript resolution with fallback logic
 5. Recursively traverse dependencies
@@ -88,10 +158,7 @@ Each file is printed as:
 
 ## Contributing
 
-We welcome contributions.
-
-Please read [`CONTRIBUTING.md`](CONTRIBUTING.md) for the source of truth on process, coding standards, and testing
-expectations.
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for process, standards, and testing expectations.
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -108,7 +107,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1768,7 +1766,6 @@
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -1818,7 +1815,6 @@
       "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.0",
         "@typescript-eslint/types": "8.59.0",
@@ -2010,7 +2006,6 @@
       "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.5",
@@ -2221,7 +2216,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2493,7 +2487,6 @@
       "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3637,7 +3630,6 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -3925,7 +3917,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -3958,7 +3949,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4024,7 +4014,6 @@
       "integrity": "sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -4103,7 +4092,6 @@
       "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.5",
         "@vitest/mocker": "4.1.5",

--- a/src/domains/output/formatter.ts
+++ b/src/domains/output/formatter.ts
@@ -1,0 +1,39 @@
+import type { ModuleFile } from "../pipeline/types.js";
+import { renderHtml } from "./html.format.js";
+import { renderMarkdown } from "./markdown.format.js";
+import { renderPlain } from "./plain.format.js";
+import { renderXml } from "./xml.format.js";
+
+const RENDERERS = {
+  plain: renderPlain,
+  markdown: renderMarkdown,
+  html: renderHtml,
+  xml: renderXml,
+} as const;
+
+type OutputFormat = keyof typeof RENDERERS;
+
+const SUPPORTED_OUTPUT_FORMATS = Object.keys(RENDERERS) as OutputFormat[];
+
+export function renderCollectedFiles(
+  files: ModuleFile[],
+  format: string | undefined,
+): string {
+  return RENDERERS[toOutputFormat(format)](files);
+}
+
+function toOutputFormat(format: string | undefined): OutputFormat {
+  const normalizedFormat = format ?? "plain";
+
+  if (isOutputFormat(normalizedFormat)) {
+    return normalizedFormat;
+  }
+
+  throw new Error(
+    `Unsupported output format: ${format}. Supported formats: ${SUPPORTED_OUTPUT_FORMATS.join(", ")}`,
+  );
+}
+
+function isOutputFormat(format: string): format is OutputFormat {
+  return SUPPORTED_OUTPUT_FORMATS.includes(format as OutputFormat);
+}

--- a/src/domains/output/html.format.ts
+++ b/src/domains/output/html.format.ts
@@ -1,0 +1,37 @@
+import type { ModuleFile } from "../pipeline/types.js";
+import { escapeXml, getRelativeFilePath } from "./utils.js";
+
+export function renderHtml(files: ModuleFile[]): string {
+  const sections = files
+    .map((file) => {
+      const relativeFilePath = getRelativeFilePath(file.filePath);
+      const escapedFilePath = escapeXml(relativeFilePath);
+      const escapedSourceCode = escapeXml(file.sourceCode);
+
+      return [
+        '<section class="code-slicer-file">',
+        `  <h3>${escapedFilePath}</h3>`,
+        `  <pre><code>${escapedSourceCode}</code></pre>`,
+        `</section>`,
+      ].join("\n");
+    })
+    .join("\n");
+
+  return [
+    "<!DOCTYPE html>",
+    '<html lang="en">',
+    "<head>",
+    '  <meta charset="UTF-8">',
+    "  <title>code-slicer output</title>",
+    "</head>",
+    "<body>",
+    '  <main class="code-slicer-output">',
+    sections
+      .split("\n")
+      .map((line) => `    ${line}`)
+      .join("\n"),
+    "  </main>",
+    "</body>",
+    "</html>",
+  ].join("\n");
+}

--- a/src/domains/output/html.format.ts
+++ b/src/domains/output/html.format.ts
@@ -9,10 +9,10 @@ export function renderHtml(files: ModuleFile[]): string {
       const escapedSourceCode = escapeXml(file.sourceCode);
 
       return [
-        '<section class="code-slicer-file">',
-        `  <h3>${escapedFilePath}</h3>`,
-        `  <pre><code>${escapedSourceCode}</code></pre>`,
-        `</section>`,
+        '    <section class="code-slicer-file">',
+        `      <h3>${escapedFilePath}</h3>`,
+        `      <pre><code>${escapedSourceCode}</code></pre>`,
+        `    </section>`,
       ].join("\n");
     })
     .join("\n");
@@ -26,10 +26,7 @@ export function renderHtml(files: ModuleFile[]): string {
     "</head>",
     "<body>",
     '  <main class="code-slicer-output">',
-    sections
-      .split("\n")
-      .map((line) => `    ${line}`)
-      .join("\n"),
+    sections,
     "  </main>",
     "</body>",
     "</html>",

--- a/src/domains/output/markdown.format.ts
+++ b/src/domains/output/markdown.format.ts
@@ -1,0 +1,29 @@
+import type { ModuleFile } from "../pipeline/types.js";
+import { getRelativeFilePath } from "./utils.js";
+
+export function renderMarkdown(files: ModuleFile[]): string {
+  return files
+    .map((file) => {
+      const relativeFilePath = getRelativeFilePath(file.filePath);
+      const fence = getMarkdownFence(file.sourceCode);
+
+      return [
+        `### ${relativeFilePath}`,
+        "",
+        fence,
+        file.sourceCode,
+        fence,
+      ].join("\n");
+    })
+    .join("\n\n");
+}
+
+function getMarkdownFence(sourceCode: string): string {
+  const backtickRuns = sourceCode.match(/`+/g) ?? [];
+  const longestRun = backtickRuns.reduce(
+    (max, run) => Math.max(max, run.length),
+    0,
+  );
+
+  return "`".repeat(Math.max(3, longestRun + 1));
+}

--- a/src/domains/output/plain.format.ts
+++ b/src/domains/output/plain.format.ts
@@ -1,0 +1,12 @@
+import type { ModuleFile } from "../pipeline/types.js";
+import { getRelativeFilePath } from "./utils.js";
+
+export function renderPlain(files: ModuleFile[]): string {
+  return files
+    .map((file) => {
+      const relativeFilePath = getRelativeFilePath(file.filePath);
+
+      return `${relativeFilePath}\n${file.sourceCode}`;
+    })
+    .join("\n\n");
+}

--- a/src/domains/output/utils.ts
+++ b/src/domains/output/utils.ts
@@ -1,0 +1,14 @@
+import NodePath from "node:path";
+
+export function getRelativeFilePath(filePath: string): string {
+  return NodePath.relative(process.cwd(), filePath);
+}
+
+export function escapeXml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}

--- a/src/domains/output/xml.format.ts
+++ b/src/domains/output/xml.format.ts
@@ -1,0 +1,25 @@
+import type { ModuleFile } from "../pipeline/types.js";
+import { escapeXml, getRelativeFilePath } from "./utils.js";
+
+export function renderXml(files: ModuleFile[]): string {
+  const fileNodes = files
+    .map((file) => {
+      const relativeFilePath = getRelativeFilePath(file.filePath);
+      const escapedFilePath = escapeXml(relativeFilePath);
+      const escapedSourceCode = escapeXml(file.sourceCode);
+
+      return [
+        `  <file path="${escapedFilePath}">`,
+        `    <source>${escapedSourceCode}</source>`,
+        "  </file>",
+      ].join("\n");
+    })
+    .join("\n");
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    "<files>",
+    fileNodes,
+    "</files>",
+  ].join("\n");
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { cac } from "cac";
-import NodePath from "node:path";
 import pkg from "../package.json" with { type: "json" };
+import { renderCollectedFiles } from "./domains/output/formatter.js";
 import { collectDependencyFiles } from "./domains/pipeline/index.js";
 
 export async function main(argv: string[]): Promise<void> {
@@ -9,18 +9,16 @@ export async function main(argv: string[]): Promise<void> {
   cli
     .command(
       "<file-path>",
-      "Collect local dependency files and output their paths and source code",
+      "Collect local dependency files and output them in the selected format",
     )
-    .action(async (filePath: string) => {
+    .option("--format <format>", "Output format (plain, markdown, html, xml)", {
+      default: "plain",
+    })
+    .action(async (filePath: string, options: { format?: string }) => {
       const files = await collectDependencyFiles(filePath);
+      const output = renderCollectedFiles(files, options.format);
 
-      for (const file of files) {
-        const relativeFilePath =
-          NodePath.relative(process.cwd(), file.filePath) || file.filePath;
-
-        process.stdout.write(`${relativeFilePath}\n`);
-        process.stdout.write(`${file.sourceCode}\n\n`);
-      }
+      process.stdout.write(`${output}\n`);
     });
 
   cli.help();

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -40,6 +40,7 @@ type MockedCli = {
   action: ReturnType<typeof vi.fn>;
   command: ReturnType<typeof vi.fn>;
   help: ReturnType<typeof vi.fn>;
+  option: ReturnType<typeof vi.fn>;
   outputHelp: ReturnType<typeof vi.fn>;
   parse: ReturnType<typeof vi.fn>;
   runMatchedCommand: ReturnType<typeof vi.fn>;
@@ -55,7 +56,8 @@ async function withMockedCac(
   const outputHelp = vi.fn();
   const parse = vi.fn();
   const runMatchedCommand = vi.fn();
-  const command = vi.fn(() => ({ action }));
+  const option = vi.fn(() => ({ action }));
+  const command = vi.fn(() => ({ option }));
   const help = vi.fn();
   const version = vi.fn();
 
@@ -78,6 +80,7 @@ async function withMockedCac(
         action,
         command,
         help,
+        option,
         outputHelp,
         parse,
         runMatchedCommand,
@@ -92,7 +95,7 @@ async function withMockedCac(
 }
 
 describe("CLI behavior", () => {
-  it("outputs dependency file paths and contents when executed via the CLI", async () => {
+  it("outputs dependency file paths and contents in plain format by default", async () => {
     await withTestProject(
       {
         "entry.ts": 'import "./dep";\n',
@@ -117,7 +120,114 @@ describe("CLI behavior", () => {
         expect(dependencyHeaderIndex).toBeGreaterThan(entryHeaderIndex);
         expect(stdout).toContain('import "./dep";\n');
         expect(stdout).toContain('export const dep = "dep";\n');
+        expect(stdout).not.toContain("```\n");
+        expect(stdout.endsWith("\n")).toBe(true);
         expect(output.stderr()).toBe("");
+      },
+    );
+  });
+
+  it("outputs dependency files as markdown when requested", async () => {
+    await withTestProject(
+      {
+        "entry.ts": 'import "./dep";\n',
+        "dep.ts": 'export const dep = "dep";\n',
+      },
+      async (projectPath) => {
+        const output = captureStreams();
+
+        try {
+          await withWorkingDirectory(projectPath, async () => {
+            await main([
+              "node",
+              "code-slicer",
+              "entry.ts",
+              "--format",
+              "markdown",
+            ]);
+          });
+        } finally {
+          output.restore();
+        }
+
+        const stdout = output.stdout();
+        const entryHeaderIndex = stdout.indexOf("### entry.ts\n");
+        const dependencyHeaderIndex = stdout.indexOf("### dep.ts\n");
+
+        expect(entryHeaderIndex).toBeGreaterThanOrEqual(0);
+        expect(dependencyHeaderIndex).toBeGreaterThan(entryHeaderIndex);
+        expect(stdout).toContain("```\n");
+        expect(stdout).toContain('import "./dep";\n');
+        expect(stdout).toContain('export const dep = "dep";\n');
+        expect(stdout).toContain("\n```\n\n### dep.ts");
+        expect(output.stderr()).toBe("");
+      },
+    );
+  });
+
+  it("outputs dependency files as html when requested", async () => {
+    await withTestProject(
+      {
+        "entry.ts": 'export const html = "<tag>";\n',
+      },
+      async (projectPath) => {
+        const output = captureStreams();
+
+        try {
+          await withWorkingDirectory(projectPath, async () => {
+            await main(["node", "code-slicer", "entry.ts", "--format", "html"]);
+          });
+        } finally {
+          output.restore();
+        }
+
+        expect(output.stdout()).toContain("<!DOCTYPE html>");
+        expect(output.stdout()).toContain('<html lang="en">');
+        expect(output.stdout()).toContain(
+          '  <main class="code-slicer-output">',
+        );
+        expect(output.stdout()).toContain("&lt;tag&gt;");
+        expect(output.stderr()).toBe("");
+      },
+    );
+  });
+
+  it("outputs dependency files as xml when requested", async () => {
+    await withTestProject(
+      {
+        "entry.ts": "export const xml = '<tag>';\n",
+      },
+      async (projectPath) => {
+        const output = captureStreams();
+
+        try {
+          await withWorkingDirectory(projectPath, async () => {
+            await main(["node", "code-slicer", "entry.ts", "--format", "xml"]);
+          });
+        } finally {
+          output.restore();
+        }
+
+        expect(output.stdout()).toContain(
+          '<?xml version="1.0" encoding="UTF-8"?>',
+        );
+        expect(output.stdout()).toContain("&lt;tag&gt;");
+        expect(output.stderr()).toBe("");
+      },
+    );
+  });
+
+  it("throws an error when an unsupported output format is provided", async () => {
+    await withTestProject(
+      {
+        "entry.ts": 'export const entry = "entry";\n',
+      },
+      async (projectPath) => {
+        await expect(
+          withWorkingDirectory(projectPath, async () => {
+            await main(["node", "code-slicer", "entry.ts", "--format", "json"]);
+          }),
+        ).rejects.toThrow("Unsupported output format: json");
       },
     );
   });
@@ -140,7 +250,14 @@ describe("CLI wiring", () => {
 
       expect(cli.command).toHaveBeenCalledWith(
         "<file-path>",
-        "Collect local dependency files and output their paths and source code",
+        "Collect local dependency files and output them in the selected format",
+      );
+      expect(cli.option).toHaveBeenCalledWith(
+        "--format <format>",
+        "Output format (plain, markdown, html, xml)",
+        {
+          default: "plain",
+        },
       );
       expect(cli.action).toHaveBeenCalledOnce();
       expect(cli.help).toHaveBeenCalledOnce();

--- a/test/formatter.test.ts
+++ b/test/formatter.test.ts
@@ -1,0 +1,178 @@
+import NodePath from "node:path";
+import { describe, expect, it } from "vitest";
+import { renderCollectedFiles } from "../src/domains/output/formatter.js";
+import { withTestProject } from "./helpers/project.js";
+
+describe("Output formatter", () => {
+  it("renders plain output by default", async () => {
+    await withTestProject(
+      {
+        "entry.ts": 'import "./dep";\n',
+        "dep.ts": 'export const dep = "dep";\n',
+      },
+      async (projectPath) => {
+        const entryFilePath = NodePath.join(projectPath, "entry.ts");
+        const dependencyFilePath = NodePath.join(projectPath, "dep.ts");
+        const entryHeading =
+          NodePath.relative(process.cwd(), entryFilePath) || entryFilePath;
+        const dependencyHeading =
+          NodePath.relative(process.cwd(), dependencyFilePath) ||
+          dependencyFilePath;
+
+        const output = renderCollectedFiles(
+          [
+            {
+              filePath: entryFilePath,
+              sourceCode: 'import "./dep";\n',
+            },
+            {
+              filePath: dependencyFilePath,
+              sourceCode: 'export const dep = "dep";\n',
+            },
+          ],
+          undefined,
+        );
+
+        expect(output).toContain(`${entryHeading}\nimport "./dep";\n`);
+        expect(output).toContain(
+          `\n\n${dependencyHeading}\nexport const dep = "dep";\n`,
+        );
+        expect(output).not.toContain("```\n");
+      },
+    );
+  });
+
+  it("renders markdown headings and fenced code blocks", async () => {
+    await withTestProject(
+      {
+        "entry.ts": 'import "./dep";\n',
+        "dep.ts": 'export const dep = "dep";\n',
+      },
+      async (projectPath) => {
+        const entryFilePath = NodePath.join(projectPath, "entry.ts");
+        const dependencyFilePath = NodePath.join(projectPath, "dep.ts");
+        const entryHeading =
+          NodePath.relative(process.cwd(), entryFilePath) || entryFilePath;
+        const dependencyHeading =
+          NodePath.relative(process.cwd(), dependencyFilePath) ||
+          dependencyFilePath;
+
+        const output = renderCollectedFiles(
+          [
+            {
+              filePath: entryFilePath,
+              sourceCode: 'import "./dep";\n',
+            },
+            {
+              filePath: dependencyFilePath,
+              sourceCode: 'export const dep = "dep";\n',
+            },
+          ],
+          "markdown",
+        );
+
+        expect(output).toContain(`### ${entryHeading}\n\n\`\`\`\n`);
+        expect(output).toContain('import "./dep";\n');
+        expect(output).toContain(
+          `\n\`\`\`\n\n### ${dependencyHeading}\n\n\`\`\`\n`,
+        );
+        expect(output).toContain('export const dep = "dep";\n');
+      },
+    );
+  });
+
+  it("renders markdown with longer fences when source contains triple backticks", async () => {
+    await withTestProject(
+      {
+        "entry.ts": 'const snippet = "```ts";\nconsole.log(snippet);\n',
+      },
+      async (projectPath) => {
+        const entryFilePath = NodePath.join(projectPath, "entry.ts");
+        const entryHeading =
+          NodePath.relative(process.cwd(), entryFilePath) || entryFilePath;
+
+        const output = renderCollectedFiles(
+          [
+            {
+              filePath: entryFilePath,
+              sourceCode: 'const snippet = "```ts";\nconsole.log(snippet);\n',
+            },
+          ],
+          "markdown",
+        );
+
+        expect(output).toContain(`### ${entryHeading}\n\n\`\`\`\`\n`);
+        expect(output).toContain('const snippet = "```ts";\n');
+        expect(output).toContain("\n````");
+      },
+    );
+  });
+
+  it("renders html sections with escaped content", async () => {
+    await withTestProject(
+      {
+        "entry.ts": 'export const html = "<tag> & value";\n',
+      },
+      async (projectPath) => {
+        const entryFilePath = NodePath.join(projectPath, "entry.ts");
+        const entryHeading =
+          NodePath.relative(process.cwd(), entryFilePath) || entryFilePath;
+
+        const output = renderCollectedFiles(
+          [
+            {
+              filePath: entryFilePath,
+              sourceCode: 'export const html = "<tag> & value";\n',
+            },
+          ],
+          "html",
+        );
+
+        expect(output).toContain("<!DOCTYPE html>");
+        expect(output).toContain('<html lang="en">');
+        expect(output).toContain("<head>");
+        expect(output).toContain('  <meta charset="UTF-8">');
+        expect(output).toContain("  <title>code-slicer output</title>");
+        expect(output).toContain("<body>");
+        expect(output).toContain('  <main class="code-slicer-output">');
+        expect(output).toContain('<section class="code-slicer-file">');
+        expect(output).toContain(`<h3>${entryHeading}</h3>`);
+        expect(output).toContain("&lt;tag&gt; &amp; value");
+        expect(output).toContain("</html>");
+      },
+    );
+  });
+
+  it("renders xml nodes with escaped content", async () => {
+    await withTestProject(
+      {
+        "entry.ts": "export const xml = '<node attr=\"ok\">';\n",
+      },
+      async (projectPath) => {
+        const entryFilePath = NodePath.join(projectPath, "entry.ts");
+        const entryHeading =
+          NodePath.relative(process.cwd(), entryFilePath) || entryFilePath;
+
+        const output = renderCollectedFiles(
+          [
+            {
+              filePath: entryFilePath,
+              sourceCode: "export const xml = '<node attr=\"ok\">';\n",
+            },
+          ],
+          "xml",
+        );
+
+        expect(output).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+        expect(output).toContain(`<file path="${entryHeading}">`);
+        expect(output).toContain("&lt;node attr=&quot;ok&quot;&gt;");
+      },
+    );
+  });
+
+  it("throws for unsupported output formats", () => {
+    expect(() => renderCollectedFiles([], "json")).toThrow(
+      "Unsupported output format: json",
+    );
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
       reporter: ["text", "lcov"],
       reportsDirectory: "./coverage",
       include: ["src/**/*.ts"],
+      exclude: ["src/entrypoint.ts"],
     },
   },
 });


### PR DESCRIPTION
## Summary

This pull request adds support for multiple output formats to the `code-slicer` CLI, allowing users to choose between plain text, markdown, HTML, and XML representations of the collected code files. The implementation includes new rendering modules for each format, updates to the CLI interface, and comprehensive tests and documentation.

### Output format support

* Added a `--format` CLI option to select the output format (`plain`, `markdown`, `html`, or `xml`), defaulting to `plain`. The CLI now outputs files using the selected format instead of always using plain text. (`src/main.ts` [[1]](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dL12-R21) [[2]](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dL2-R3); `README.md` [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R27-R30) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L38-R59) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L52-R126)
* Implemented a central `renderCollectedFiles` function and supporting format renderers: `renderPlain`, `renderMarkdown`, `renderHtml`, and `renderXml`, each producing output in the corresponding format. (`src/domains/output/formatter.ts` [[1]](diffhunk://#diff-7e6ae86ed954f859eecdc53f571f7affdc9261c690e542222c501cb77daf47c8R1-R39); `src/domains/output/plain.format.ts` [[2]](diffhunk://#diff-68a14da7ba52955d93702c3077a3568d9e2a2b7e6f3be35b094baeeacf0701cfR1-R12); `src/domains/output/markdown.format.ts` [[3]](diffhunk://#diff-f0e2688c03badd61a0a239e6af33995dbe1517d3883be8cdab39be0832fa1d82R1-R29); `src/domains/output/html.format.ts` [[4]](diffhunk://#diff-5386f1eb70a94032bf3006c124c33162eef8b6ebc6d13da22e227fbf89fe8861R1-R37); `src/domains/output/xml.format.ts` [[5]](diffhunk://#diff-4ea3f8108bbbb39348d18ea4400b4dbecb33dfb52e9d53938eefa68284e5f54fR1-R25)
* Added utility functions for path normalization and XML escaping to ensure correct and safe output in all formats. (`src/domains/output/utils.ts` [src/domains/output/utils.tsR1-R14](diffhunk://#diff-871aa09a79b3f6bed35227c970fd58dcfd221ae24fd503b645109fa9ecbfb150R1-R14))

### Documentation

* Updated the `README.md` to describe the new output formats, provide usage examples, and show sample outputs for each format. Also clarified some language and simplified the contributing section. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L10-R11) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R27-R30) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L38-R59) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L52-R126) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L91-R161)

### Testing

* Extended and improved CLI tests to cover all supported output formats, verify correct output, and ensure errors are thrown for unsupported formats. Updated test mocks to support the new CLI option. (`test/cli.test.ts` [[1]](diffhunk://#diff-1deee0a575599b2df117c280da319f7938aaf6fdb0c04bcdbde769dbf464be69R43) [[2]](diffhunk://#diff-1deee0a575599b2df117c280da319f7938aaf6fdb0c04bcdbde769dbf464be69L58-R60) [[3]](diffhunk://#diff-1deee0a575599b2df117c280da319f7938aaf6fdb0c04bcdbde769dbf464be69R83) [[4]](diffhunk://#diff-1deee0a575599b2df117c280da319f7938aaf6fdb0c04bcdbde769dbf464be69L95-R98) [[5]](diffhunk://#diff-1deee0a575599b2df117c280da319f7938aaf6fdb0c04bcdbde769dbf464be69R123-R234) [[6]](diffhunk://#diff-1deee0a575599b2df117c280da319f7938aaf6fdb0c04bcdbde769dbf464be69L143-R260)

These changes make `code-slicer` more flexible and suitable for a variety of AI and developer workflows, while improving code structure, test coverage, and documentation.

## Related issue

Closes #3 

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [x] Test improvement

## Validation

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run knip`
- [x] `npm test`
- [x] `npm run build`

## Checklist

- [x] PR targets `main`.
- [x] The change is linked to an issue, or an issue is not required.
- [x] The solution is minimal and intentional.
- [x] Tests were added or updated for behavior changes.
- [x] Documentation was updated where relevant.
