### PR TITLE
test: refactor project helpers

### DIFF
--- a/test/cli.rejection.test.ts
+++ b/test/cli.rejection.test.ts
@@ -1,17 +1,17 @@
 import { describe, expect, it } from "vitest";
 import { main } from "../src/main.js";
 import { withWorkingDirectory } from "./helpers/cwd.js";
-import { withTestProject } from "./helpers/project.js";
+import { withProject } from "./helpers/project.js";
 
 describe("CLI errors", () => {
   it("throws for unsupported output format", async () => {
-    await withTestProject(
+    await withProject(
       {
         "entry.ts": 'export const entry = "entry";\n',
       },
-      async (projectPath) => {
+      async (project) => {
         await expect(
-          withWorkingDirectory(projectPath, async () => {
+          withWorkingDirectory(project.root, async () => {
             await main(["node", "code-slicer", "entry.ts", "--format", "json"]);
           }),
         ).rejects.toThrow("Unsupported output format: json");
@@ -20,9 +20,9 @@ describe("CLI errors", () => {
   });
 
   it("throws when the specified entry file does not exist", async () => {
-    await withTestProject({}, async (projectPath) => {
+    await withProject({}, async (project) => {
       await expect(
-        withWorkingDirectory(projectPath, async () => {
+        withWorkingDirectory(project.root, async () => {
           await main(["node", "code-slicer", "missing.ts"]);
         }),
       ).rejects.toThrow("Entry file not found:");

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import pkg from "../package.json" with { type: "json" };
 import { main } from "../src/main.js";
 import { withWorkingDirectory } from "./helpers/cwd.js";
-import { withTestProject } from "./helpers/project.js";
+import { withProject } from "./helpers/project.js";
 import { captureStreams } from "./helpers/streams.js";
 
 type MockedCli = {
@@ -65,16 +65,16 @@ async function withMockedCac(
 
 describe("CLI behavior", () => {
   it("outputs dependency file paths and contents in plain format by default", async () => {
-    await withTestProject(
+    await withProject(
       {
         "entry.ts": 'import "./dep";\n',
         "dep.ts": 'export const dep = "dep";\n',
       },
-      async (projectPath) => {
+      async (project) => {
         const output = captureStreams();
 
         try {
-          await withWorkingDirectory(projectPath, async () => {
+          await withWorkingDirectory(project.root, async () => {
             await main(["node", "code-slicer", "entry.ts"]);
           });
         } finally {
@@ -97,16 +97,16 @@ describe("CLI behavior", () => {
   });
 
   it("outputs dependency files as markdown when requested", async () => {
-    await withTestProject(
+    await withProject(
       {
         "entry.ts": 'import "./dep";\n',
         "dep.ts": 'export const dep = "dep";\n',
       },
-      async (projectPath) => {
+      async (project) => {
         const output = captureStreams();
 
         try {
-          await withWorkingDirectory(projectPath, async () => {
+          await withWorkingDirectory(project.root, async () => {
             await main([
               "node",
               "code-slicer",
@@ -135,15 +135,15 @@ describe("CLI behavior", () => {
   });
 
   it("outputs dependency files as html when requested", async () => {
-    await withTestProject(
+    await withProject(
       {
         "entry.ts": 'export const html = "<tag>";\n',
       },
-      async (projectPath) => {
+      async (project) => {
         const output = captureStreams();
 
         try {
-          await withWorkingDirectory(projectPath, async () => {
+          await withWorkingDirectory(project.root, async () => {
             await main(["node", "code-slicer", "entry.ts", "--format", "html"]);
           });
         } finally {
@@ -162,15 +162,15 @@ describe("CLI behavior", () => {
   });
 
   it("outputs dependency files as xml when requested", async () => {
-    await withTestProject(
+    await withProject(
       {
         "entry.ts": "export const xml = '<tag>';\n",
       },
-      async (projectPath) => {
+      async (project) => {
         const output = captureStreams();
 
         try {
-          await withWorkingDirectory(projectPath, async () => {
+          await withWorkingDirectory(project.root, async () => {
             await main(["node", "code-slicer", "entry.ts", "--format", "xml"]);
           });
         } finally {

--- a/test/collector.rejection.test.ts
+++ b/test/collector.rejection.test.ts
@@ -1,15 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { collectDependencyFiles } from "../src/domains/pipeline/index.js";
 import { withWorkingDirectory } from "./helpers/cwd.js";
-import { getProjectFilePath, withTestProject } from "./helpers/project.js";
+import { withProject } from "./helpers/project.js";
 
 describe("Dependency collection errors", () => {
   it("throws when the entry file does not exist", async () => {
-    await withTestProject({}, async (projectPath) => {
-      const missingEntryPath = getProjectFilePath(
-        projectPath,
-        "missing-entry.ts",
-      );
+    await withProject({}, async (project) => {
+      const missingEntryPath = project.path("missing-entry.ts");
 
       await expect(collectDependencyFiles(missingEntryPath)).rejects.toThrow(
         `Entry file not found: ${missingEntryPath}`,
@@ -18,15 +15,15 @@ describe("Dependency collection errors", () => {
   });
 
   it("throws when tsconfig.json is invalid", async () => {
-    await withTestProject(
+    await withProject(
       {
         "entry.ts": 'export const value = "entry";\n',
         "tsconfig.json": "{",
       },
-      async (projectPath) => {
-        await withWorkingDirectory(projectPath, async () => {
+      async (project) => {
+        await withWorkingDirectory(project.root, async () => {
           await expect(
-            collectDependencyFiles(getProjectFilePath(projectPath, "entry.ts")),
+            collectDependencyFiles(project.path("entry.ts")),
           ).rejects.toThrow();
         });
       },

--- a/test/collector.test.ts
+++ b/test/collector.test.ts
@@ -1,10 +1,7 @@
+import NodePath from "node:path";
 import { describe, expect, it } from "vitest";
 import { collectDependencyFiles } from "../src/domains/pipeline/index.js";
-import {
-  getProjectFilePath,
-  getRelativeFilePaths,
-  withTestProject,
-} from "./helpers/project.js";
+import { withProject } from "./helpers/project.js";
 
 describe("Dependency collection", () => {
   it.each([
@@ -16,20 +13,19 @@ describe("Dependency collection", () => {
     async (extension, baseName, sourceCode) => {
       const assetFileName = `${baseName}.${extension}`;
 
-      await withTestProject(
+      await withProject(
         {
           "entry.ts": `import "./${assetFileName}";\n`,
           [assetFileName]: sourceCode,
         },
-        async (projectPath) => {
-          const files = await collectDependencyFiles(
-            getProjectFilePath(projectPath, "entry.ts"),
-          );
+        async (project) => {
+          const files = await collectDependencyFiles(project.path("entry.ts"));
 
-          expect(getRelativeFilePaths(projectPath, files)).toEqual([
-            "entry.ts",
-            assetFileName,
-          ]);
+          expect(
+            files.map(({ filePath }) =>
+              NodePath.relative(project.root, filePath),
+            ),
+          ).toEqual(["entry.ts", assetFileName]);
         },
       );
     },

--- a/test/frameworks/angular.test.ts
+++ b/test/frameworks/angular.test.ts
@@ -1,14 +1,11 @@
+import NodePath from "node:path";
 import { describe, expect, it } from "vitest";
 import { collectDependencyFiles } from "../../src/domains/pipeline/index.js";
-import {
-  getProjectFilePath,
-  getRelativeFilePaths,
-  withTestProject,
-} from "../helpers/project.js";
+import { withProject } from "../helpers/project.js";
 
 describe("Angular file collection", () => {
   it("collects TypeScript dependencies imported by a file with Angular component metadata", async () => {
-    await withTestProject(
+    await withProject(
       {
         "entry.ts":
           'import { AppComponent } from "./app.component";\nvoid AppComponent;\n',
@@ -27,16 +24,14 @@ describe("Angular file collection", () => {
         "app.component.html": "<p>Hello</p>\n",
         "app.component.scss": "p { color: red; }\n",
       },
-      async (projectPath) => {
-        const files = await collectDependencyFiles(
-          getProjectFilePath(projectPath, "entry.ts"),
-        );
+      async (project) => {
+        const files = await collectDependencyFiles(project.path("entry.ts"));
 
-        expect(getRelativeFilePaths(projectPath, files)).toEqual([
-          "entry.ts",
-          "app.component.ts",
-          "helper.ts",
-        ]);
+        expect(
+          files.map(({ filePath }) =>
+            NodePath.relative(project.root, filePath),
+          ),
+        ).toEqual(["entry.ts", "app.component.ts", "helper.ts"]);
       },
     );
   });

--- a/test/frameworks/react.test.ts
+++ b/test/frameworks/react.test.ts
@@ -1,48 +1,43 @@
+import NodePath from "node:path";
 import { describe, expect, it } from "vitest";
 import { collectDependencyFiles } from "../../src/domains/pipeline/index.js";
-import {
-  getProjectFilePath,
-  getRelativeFilePaths,
-  withTestProject,
-} from "../helpers/project.js";
+import { withProject } from "../helpers/project.js";
 
 describe("React file collection", () => {
   it("collects dependencies from a JSX entry", async () => {
-    await withTestProject(
+    await withProject(
       {
         "entry.jsx":
           'import { dep } from "./dep.js";\nexport function App() {\n  return <div>{dep}</div>;\n}\n',
         "dep.js": 'export const dep = "jsx";\n',
       },
-      async (projectPath) => {
-        const files = await collectDependencyFiles(
-          getProjectFilePath(projectPath, "entry.jsx"),
-        );
+      async (project) => {
+        const files = await collectDependencyFiles(project.path("entry.jsx"));
 
-        expect(getRelativeFilePaths(projectPath, files)).toEqual([
-          "entry.jsx",
-          "dep.js",
-        ]);
+        expect(
+          files.map(({ filePath }) =>
+            NodePath.relative(project.root, filePath),
+          ),
+        ).toEqual(["entry.jsx", "dep.js"]);
       },
     );
   });
 
   it("collects dependencies from a TSX entry", async () => {
-    await withTestProject(
+    await withProject(
       {
         "entry.tsx":
           'import { dep } from "./dep";\nexport function App() {\n  return <div>{dep}</div>;\n}\n',
         "dep.ts": 'export const dep = "tsx";\n',
       },
-      async (projectPath) => {
-        const files = await collectDependencyFiles(
-          getProjectFilePath(projectPath, "entry.tsx"),
-        );
+      async (project) => {
+        const files = await collectDependencyFiles(project.path("entry.tsx"));
 
-        expect(getRelativeFilePaths(projectPath, files)).toEqual([
-          "entry.tsx",
-          "dep.ts",
-        ]);
+        expect(
+          files.map(({ filePath }) =>
+            NodePath.relative(project.root, filePath),
+          ),
+        ).toEqual(["entry.tsx", "dep.ts"]);
       },
     );
   });

--- a/test/frameworks/vue.rejection.test.ts
+++ b/test/frameworks/vue.rejection.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { collectDependencyFiles } from "../../src/domains/pipeline/index.js";
-import { getProjectFilePath, withTestProject } from "../helpers/project.js";
+import { withProject } from "../helpers/project.js";
 
 type MockedCompilerErrorCase = {
   expected: string | RegExp;
@@ -10,15 +10,15 @@ type MockedCompilerErrorCase = {
 
 describe("Vue file collection errors", () => {
   it("throws when the Vue file cannot be parsed", async () => {
-    await withTestProject(
+    await withProject(
       {
         "entry.vue": "<script setup>\n",
       },
-      async (projectPath) => {
+      async (project) => {
         await expect(
-          collectDependencyFiles(getProjectFilePath(projectPath, "entry.vue")),
+          collectDependencyFiles(project.path("entry.vue")),
         ).rejects.toThrow(
-          `Failed to parse Vue file: ${getProjectFilePath(projectPath, "entry.vue")}`,
+          `Failed to parse Vue file: ${project.path("entry.vue")}`,
         );
       },
     );
@@ -70,11 +70,11 @@ describe("Vue file collection errors", () => {
       thrown: "unexpected",
     },
   ])("handles compiler load failure %#", async ({ thrown, mode, expected }) => {
-    await withTestProject(
+    await withProject(
       {
         "entry.vue": '<script setup>\nimport "./dep";\n</script>\n',
       },
-      async (projectPath) => {
+      async (project) => {
         vi.resetModules();
 
         vi.doMock("node:module", async () => {
@@ -100,9 +100,7 @@ describe("Vue file collection errors", () => {
           const { collectDependencyFiles: collectDependencyFilesWithMock } =
             await import("../../src/domains/pipeline/index.js");
 
-          const run = collectDependencyFilesWithMock(
-            getProjectFilePath(projectPath, "entry.vue"),
-          );
+          const run = collectDependencyFilesWithMock(project.path("entry.vue"));
 
           if (mode === "toThrow") {
             await expect(run).rejects.toThrow(expected);

--- a/test/frameworks/vue.test.ts
+++ b/test/frameworks/vue.test.ts
@@ -1,24 +1,23 @@
+import NodePath from "node:path";
 import { describe, expect, it } from "vitest";
 import { collectDependencyFiles } from "../../src/domains/pipeline/index.js";
-import {
-  getProjectFilePath,
-  getRelativeFilePaths,
-  withTestProject,
-} from "../helpers/project.js";
+import { withProject } from "../helpers/project.js";
 
 describe("Vue file collection", () => {
   async function expectCollectedFiles(
     files: Record<string, string>,
     expected: string[],
   ): Promise<void> {
-    await withTestProject(files, async (projectPath) => {
+    await withProject(files, async (project) => {
       const collectedFiles = await collectDependencyFiles(
-        getProjectFilePath(projectPath, "entry.vue"),
+        project.path("entry.vue"),
       );
 
-      expect(getRelativeFilePaths(projectPath, collectedFiles)).toEqual(
-        expected,
-      );
+      expect(
+        collectedFiles.map(({ filePath }) =>
+          NodePath.relative(project.root, filePath),
+        ),
+      ).toEqual(expected);
     });
   }
 

--- a/test/helpers/project.ts
+++ b/test/helpers/project.ts
@@ -1,40 +1,48 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import NodeFS from "node:fs/promises";
+import NodeOS from "node:os";
 import NodePath from "node:path";
-import type { ModuleFile } from "../../src/domains/pipeline/types.js";
+import pkg from "../../package.json" with { type: "json" };
 
-export async function withTestProject(
+type ProjectContext = {
+  root: string;
+  path: (relativeFilePath: string) => string;
+  chdir: () => void;
+};
+
+export async function withProject<T>(
   files: Record<string, string>,
-  run: (projectPath: string) => Promise<void>,
-): Promise<void> {
-  const projectPath = await mkdtemp(
-    NodePath.join(tmpdir(), "code-slicer-test-"),
+  run: (project: ProjectContext) => Promise<T>,
+): Promise<T> {
+  const initialCwd = process.cwd();
+  const root = await NodeFS.realpath(
+    await NodeFS.mkdtemp(NodePath.join(NodeOS.tmpdir(), `${pkg.name}-`)),
   );
 
-  try {
-    for (const [relativeFilePath, sourceCode] of Object.entries(files)) {
-      const filePath = NodePath.join(projectPath, relativeFilePath);
+  const project: ProjectContext = {
+    root,
+    path: (relativeFilePath) => {
+      if (NodePath.isAbsolute(relativeFilePath)) {
+        throw new Error("Project file path must be relative");
+      }
 
-      await mkdir(NodePath.dirname(filePath), { recursive: true });
-      await writeFile(filePath, sourceCode);
+      return NodePath.join(root, relativeFilePath);
+    },
+    chdir: () => {
+      process.chdir(root);
+    },
+  };
+
+  try {
+    for (const [relativeFilePath, content] of Object.entries(files)) {
+      const filePath = project.path(relativeFilePath);
+
+      await NodeFS.mkdir(NodePath.dirname(filePath), { recursive: true });
+      await NodeFS.writeFile(filePath, content, "utf8");
     }
 
-    await run(projectPath);
+    return await run(project);
   } finally {
-    await rm(projectPath, { recursive: true, force: true });
+    process.chdir(initialCwd);
+    await NodeFS.rm(root, { recursive: true, force: true });
   }
-}
-
-export function getProjectFilePath(
-  projectPath: string,
-  relativeFilePath: string,
-): string {
-  return NodePath.join(projectPath, relativeFilePath);
-}
-
-export function getRelativeFilePaths(
-  projectPath: string,
-  files: ModuleFile[],
-): string[] {
-  return files.map((file) => NodePath.relative(projectPath, file.filePath));
 }

--- a/test/helpers/streams.ts
+++ b/test/helpers/streams.ts
@@ -1,23 +1,33 @@
 import { vi } from "vitest";
 
+function decodeChunk(chunk: unknown): string {
+  if (typeof chunk === "string") {
+    return chunk;
+  }
+
+  if (chunk instanceof Uint8Array) {
+    return Buffer.from(chunk).toString("utf8");
+  }
+
+  return String(chunk);
+}
+
 export function captureStreams() {
   let stdout = "";
   let stderr = "";
 
   const stdoutSpy = vi
     .spyOn(process.stdout, "write")
-    .mockImplementation((chunk: string | Uint8Array) => {
-      stdout +=
-        typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
+    .mockImplementation((chunk: unknown) => {
+      stdout += decodeChunk(chunk);
 
       return true;
     });
 
   const stderrSpy = vi
     .spyOn(process.stderr, "write")
-    .mockImplementation((chunk: string | Uint8Array) => {
-      stderr +=
-        typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
+    .mockImplementation((chunk: unknown) => {
+      stderr += decodeChunk(chunk);
 
       return true;
     });

--- a/test/languages/css.test.ts
+++ b/test/languages/css.test.ts
@@ -1,29 +1,25 @@
+import NodePath from "node:path";
 import { describe, expect, it } from "vitest";
 import { collectDependencyFiles } from "../../src/domains/pipeline/index.js";
-import {
-  getProjectFilePath,
-  getRelativeFilePaths,
-  withTestProject,
-} from "../helpers/project.js";
+import { withProject } from "../helpers/project.js";
 
 describe("Stylesheet file collection", () => {
   it.each(["css", "scss", "less"])(
     "includes explicitly imported .%s stylesheet files",
     async (extension) => {
-      await withTestProject(
+      await withProject(
         {
           "entry.js": `import "./styles.${extension}";\n`,
           [`styles.${extension}`]: "body { color: black; }\n",
         },
-        async (projectPath) => {
-          const files = await collectDependencyFiles(
-            getProjectFilePath(projectPath, "entry.js"),
-          );
+        async (project) => {
+          const files = await collectDependencyFiles(project.path("entry.js"));
 
-          expect(getRelativeFilePaths(projectPath, files)).toEqual([
-            "entry.js",
-            `styles.${extension}`,
-          ]);
+          expect(
+            files.map(({ filePath }) =>
+              NodePath.relative(project.root, filePath),
+            ),
+          ).toEqual(["entry.js", `styles.${extension}`]);
         },
       );
     },

--- a/test/languages/javascript.test.ts
+++ b/test/languages/javascript.test.ts
@@ -1,67 +1,61 @@
+import NodePath from "node:path";
 import { describe, expect, it } from "vitest";
 import { collectDependencyFiles } from "../../src/domains/pipeline/index.js";
 import { withWorkingDirectory } from "../helpers/cwd.js";
-import {
-  getProjectFilePath,
-  getRelativeFilePaths,
-  withTestProject,
-} from "../helpers/project.js";
+import { withProject } from "../helpers/project.js";
 
 describe("JavaScript file collection", () => {
   it("collects an ESM entry and its local dependency", async () => {
-    await withTestProject(
+    await withProject(
       {
         "entry.mjs": 'import { dep } from "./dep.js";\nconsole.log(dep);\n',
         "dep.js": 'export const dep = "esm";\n',
       },
-      async (projectPath) => {
-        const files = await collectDependencyFiles(
-          getProjectFilePath(projectPath, "entry.mjs"),
-        );
+      async (project) => {
+        const files = await collectDependencyFiles(project.path("entry.mjs"));
 
-        expect(getRelativeFilePaths(projectPath, files)).toEqual([
-          "entry.mjs",
-          "dep.js",
-        ]);
+        expect(
+          files.map(({ filePath }) =>
+            NodePath.relative(project.root, filePath),
+          ),
+        ).toEqual(["entry.mjs", "dep.js"]);
       },
     );
   });
 
   it("collects a CJS entry that uses dynamic import", async () => {
-    await withTestProject(
+    await withProject(
       {
         "entry.cjs": 'import("./dep.cjs");\nmodule.exports = {};\n',
         "dep.cjs": 'module.exports = { dep: "cjs" };\n',
       },
-      async (projectPath) => {
-        const files = await collectDependencyFiles(
-          getProjectFilePath(projectPath, "entry.cjs"),
-        );
+      async (project) => {
+        const files = await collectDependencyFiles(project.path("entry.cjs"));
 
-        expect(getRelativeFilePaths(projectPath, files)).toEqual([
-          "entry.cjs",
-          "dep.cjs",
-        ]);
+        expect(
+          files.map(({ filePath }) =>
+            NodePath.relative(project.root, filePath),
+          ),
+        ).toEqual(["entry.cjs", "dep.cjs"]);
       },
     );
   });
 
   it("collects dependencies in a pure JavaScript project without tsconfig.json", async () => {
-    await withTestProject(
+    await withProject(
       {
         "entry.js": 'import "./dep.js";\n',
         "dep.js": 'export const dep = "js";\n',
       },
-      async (projectPath) => {
-        await withWorkingDirectory(projectPath, async () => {
-          const files = await collectDependencyFiles(
-            getProjectFilePath(projectPath, "entry.js"),
-          );
+      async (project) => {
+        await withWorkingDirectory(project.root, async () => {
+          const files = await collectDependencyFiles(project.path("entry.js"));
 
-          expect(getRelativeFilePaths(projectPath, files)).toEqual([
-            "entry.js",
-            "dep.js",
-          ]);
+          expect(
+            files.map(({ filePath }) =>
+              NodePath.relative(project.root, filePath),
+            ),
+          ).toEqual(["entry.js", "dep.js"]);
         });
       },
     );

--- a/test/languages/typescript.test.ts
+++ b/test/languages/typescript.test.ts
@@ -1,14 +1,11 @@
+import NodePath from "node:path";
 import { describe, expect, it } from "vitest";
 import { collectDependencyFiles } from "../../src/domains/pipeline/index.js";
-import {
-  getProjectFilePath,
-  getRelativeFilePaths,
-  withTestProject,
-} from "../helpers/project.js";
+import { withProject } from "../helpers/project.js";
 
 describe("TypeScript file collection", () => {
   it("collects dependencies in traversal order", async () => {
-    await withTestProject(
+    await withProject(
       {
         "entry.ts":
           'import { dep } from "./dep";\nexport { helper } from "./helper";\nconsole.log(dep, helper);\n',
@@ -17,56 +14,51 @@ describe("TypeScript file collection", () => {
         "nested.ts": 'export const nested = "nested";\n',
         "helper/index.ts": 'export const helper = "helper";\n',
       },
-      async (projectPath) => {
-        const files = await collectDependencyFiles(
-          getProjectFilePath(projectPath, "entry.ts"),
-        );
+      async (project) => {
+        const files = await collectDependencyFiles(project.path("entry.ts"));
 
-        expect(getRelativeFilePaths(projectPath, files)).toEqual([
-          "entry.ts",
-          "dep.ts",
-          "nested.ts",
-          "helper/index.ts",
-        ]);
+        expect(
+          files.map(({ filePath }) =>
+            NodePath.relative(project.root, filePath),
+          ),
+        ).toEqual(["entry.ts", "dep.ts", "nested.ts", "helper/index.ts"]);
       },
     );
   });
 
   it("keeps resolvable imports and skips missing or external modules", async () => {
-    await withTestProject(
+    await withProject(
       {
         "entry.ts":
           'import { present } from "./present";\nimport "./missing";\nimport "not-installed-package";\nvoid import("./missing-dynamic");\nconsole.log(present);\n',
         "present.ts": 'export const present = "ok";\n',
       },
-      async (projectPath) => {
-        const files = await collectDependencyFiles(
-          getProjectFilePath(projectPath, "entry.ts"),
-        );
+      async (project) => {
+        const files = await collectDependencyFiles(project.path("entry.ts"));
 
-        expect(getRelativeFilePaths(projectPath, files)).toEqual([
-          "entry.ts",
-          "present.ts",
-        ]);
+        expect(
+          files.map(({ filePath }) =>
+            NodePath.relative(project.root, filePath),
+          ),
+        ).toEqual(["entry.ts", "present.ts"]);
       },
     );
   });
 
   it("does not recurse forever when files import each other", async () => {
-    await withTestProject(
+    await withProject(
       {
         "a.ts": 'import "./b";\nexport const a = "a";\n',
         "b.ts": 'import "./a";\nexport const b = "b";\n',
       },
-      async (projectPath) => {
-        const files = await collectDependencyFiles(
-          getProjectFilePath(projectPath, "a.ts"),
-        );
+      async (project) => {
+        const files = await collectDependencyFiles(project.path("a.ts"));
 
-        expect(getRelativeFilePaths(projectPath, files)).toEqual([
-          "a.ts",
-          "b.ts",
-        ]);
+        expect(
+          files.map(({ filePath }) =>
+            NodePath.relative(project.root, filePath),
+          ),
+        ).toEqual(["a.ts", "b.ts"]);
       },
     );
   });

--- a/test/output/html.format.test.ts
+++ b/test/output/html.format.test.ts
@@ -1,16 +1,16 @@
 import NodePath from "node:path";
 import { describe, expect, it } from "vitest";
 import { renderCollectedFiles } from "../../src/domains/output/formatter.js";
-import { withTestProject } from "../helpers/project.js";
+import { withProject } from "../helpers/project.js";
 
 describe("HTML output format", () => {
   it("renders html sections with escaped content", async () => {
-    await withTestProject(
+    await withProject(
       {
         "entry.ts": 'export const html = "<tag> & value";\n',
       },
-      async (projectPath) => {
-        const entryFilePath = NodePath.join(projectPath, "entry.ts");
+      async (project) => {
+        const entryFilePath = NodePath.join(project.root, "entry.ts");
         const entryHeading =
           NodePath.relative(process.cwd(), entryFilePath) || entryFilePath;
 

--- a/test/output/markdown.format.test.ts
+++ b/test/output/markdown.format.test.ts
@@ -1,18 +1,18 @@
 import NodePath from "node:path";
 import { describe, expect, it } from "vitest";
 import { renderCollectedFiles } from "../../src/domains/output/formatter.js";
-import { withTestProject } from "../helpers/project.js";
+import { withProject } from "../helpers/project.js";
 
 describe("Markdown output format", () => {
   it("renders markdown headings and fenced code blocks", async () => {
-    await withTestProject(
+    await withProject(
       {
         "entry.ts": 'import "./dep";\n',
         "dep.ts": 'export const dep = "dep";\n',
       },
-      async (projectPath) => {
-        const entryFilePath = NodePath.join(projectPath, "entry.ts");
-        const dependencyFilePath = NodePath.join(projectPath, "dep.ts");
+      async (project) => {
+        const entryFilePath = NodePath.join(project.root, "entry.ts");
+        const dependencyFilePath = NodePath.join(project.root, "dep.ts");
         const entryHeading =
           NodePath.relative(process.cwd(), entryFilePath) || entryFilePath;
         const dependencyHeading =
@@ -44,12 +44,12 @@ describe("Markdown output format", () => {
   });
 
   it("renders markdown with longer fences when source contains triple backticks", async () => {
-    await withTestProject(
+    await withProject(
       {
         "entry.ts": 'const snippet = "```ts";\nconsole.log(snippet);\n',
       },
-      async (projectPath) => {
-        const entryFilePath = NodePath.join(projectPath, "entry.ts");
+      async (project) => {
+        const entryFilePath = NodePath.join(project.root, "entry.ts");
         const entryHeading =
           NodePath.relative(process.cwd(), entryFilePath) || entryFilePath;
 

--- a/test/output/plain.format.test.ts
+++ b/test/output/plain.format.test.ts
@@ -1,18 +1,18 @@
 import NodePath from "node:path";
 import { describe, expect, it } from "vitest";
 import { renderCollectedFiles } from "../../src/domains/output/formatter.js";
-import { withTestProject } from "../helpers/project.js";
+import { withProject } from "../helpers/project.js";
 
 describe("Plain output format", () => {
   it("renders plain output by default", async () => {
-    await withTestProject(
+    await withProject(
       {
         "entry.ts": 'import "./dep";\n',
         "dep.ts": 'export const dep = "dep";\n',
       },
-      async (projectPath) => {
-        const entryFilePath = NodePath.join(projectPath, "entry.ts");
-        const dependencyFilePath = NodePath.join(projectPath, "dep.ts");
+      async (project) => {
+        const entryFilePath = NodePath.join(project.root, "entry.ts");
+        const dependencyFilePath = NodePath.join(project.root, "dep.ts");
         const entryHeading =
           NodePath.relative(process.cwd(), entryFilePath) || entryFilePath;
         const dependencyHeading =

--- a/test/output/xml.format.test.ts
+++ b/test/output/xml.format.test.ts
@@ -1,16 +1,16 @@
 import NodePath from "node:path";
 import { describe, expect, it } from "vitest";
 import { renderCollectedFiles } from "../../src/domains/output/formatter.js";
-import { withTestProject } from "../helpers/project.js";
+import { withProject } from "../helpers/project.js";
 
 describe("XML output format", () => {
   it("renders xml nodes with escaped content", async () => {
-    await withTestProject(
+    await withProject(
       {
         "entry.ts": "export const xml = '<node attr=\"ok\">';\n",
       },
-      async (projectPath) => {
-        const entryFilePath = NodePath.join(projectPath, "entry.ts");
+      async (project) => {
+        const entryFilePath = NodePath.join(project.root, "entry.ts");
         const entryHeading =
           NodePath.relative(process.cwd(), entryFilePath) || entryFilePath;
 

--- a/test/resolver.test.ts
+++ b/test/resolver.test.ts
@@ -1,7 +1,7 @@
 import TypeScript from "typescript";
 import { describe, expect, it } from "vitest";
 import { resolveImportFilePath } from "../src/domains/pipeline/resolver.js";
-import { getProjectFilePath, withTestProject } from "./helpers/project.js";
+import { withProject } from "./helpers/project.js";
 
 const compilerOptions: TypeScript.CompilerOptions = {
   module: TypeScript.ModuleKind.NodeNext,
@@ -10,7 +10,7 @@ const compilerOptions: TypeScript.CompilerOptions = {
 
 describe("Import resolver", () => {
   it("drops imports resolved to node_modules", async () => {
-    await withTestProject(
+    await withProject(
       {
         "entry.ts": 'import "example-pkg";\n',
         "node_modules/example-pkg/package.json":
@@ -18,10 +18,10 @@ describe("Import resolver", () => {
         "node_modules/example-pkg/index.js":
           'export const value = "external";\n',
       },
-      async (projectPath) => {
+      async (project) => {
         const resolvedPath = await resolveImportFilePath(
           "example-pkg",
-          getProjectFilePath(projectPath, "entry.ts"),
+          project.path("entry.ts"),
           compilerOptions,
         );
 
@@ -31,14 +31,14 @@ describe("Import resolver", () => {
   });
 
   it("falls back to candidate file search when TypeScript resolution misses", async () => {
-    await withTestProject(
+    await withProject(
       {
         "entry.ts": 'import "./dep";\n',
         "dep.cjs": 'module.exports = { dep: "dep" };\n',
       },
-      async (projectPath) => {
-        const fromFilePath = getProjectFilePath(projectPath, "entry.ts");
-        const depFilePath = getProjectFilePath(projectPath, "dep.cjs");
+      async (project) => {
+        const fromFilePath = project.path("entry.ts");
+        const depFilePath = project.path("dep.cjs");
 
         const resolvedByTypeScript =
           TypeScript.resolveModuleName(
@@ -62,13 +62,13 @@ describe("Import resolver", () => {
   });
 
   it("ignores fallback resolutions that resolve to files inside node_modules", async () => {
-    await withTestProject(
+    await withProject(
       {
         "entry.ts": 'import "./node_modules/example-pkg";\n',
         "node_modules/example-pkg/index.vue": "<template><div /></template>\n",
       },
-      async (projectPath) => {
-        const fromFilePath = getProjectFilePath(projectPath, "entry.ts");
+      async (project) => {
+        const fromFilePath = project.path("entry.ts");
 
         const resolvedByTypeScript =
           TypeScript.resolveModuleName(


### PR DESCRIPTION
## Summary

This pull request refactors the test project helper utilities to use a new `withProject` function, replacing the older `withTestProject` and related helpers. The new approach provides a richer project context object for tests, simplifies file path handling, and removes redundant code. All affected tests are updated to use the new helper, improving test readability and maintainability.

**Test helper refactoring:**

* Replaced `withTestProject`, `getProjectFilePath`, and `getRelativeFilePaths` with a new `withProject` helper in `test/helpers/project.ts`. The new helper provides a `project` context with `root`, `path`, and `chdir` methods, and ensures proper cleanup and error handling.

* Updated all test files (`test/cli.rejection.test.ts`, `test/cli.test.ts`, `test/collector.test.ts`, `test/collector.rejection.test.ts`, `test/frameworks/angular.test.ts`, `test/frameworks/react.test.ts`, `test/frameworks/vue.test.ts`, `test/frameworks/vue.rejection.test.ts`, `test/languages/css.test.ts`) to use the new `withProject` helper and the improved project context for file path operations and assertions. [[1]](diffhunk://#diff-e249dad9d6db9de63d8e6cdd869967e86f749d645dc906ea27b7b3f8b6d6efbdL4-R14) [[2]](diffhunk://#diff-e249dad9d6db9de63d8e6cdd869967e86f749d645dc906ea27b7b3f8b6d6efbdL23-R25) [[3]](diffhunk://#diff-1deee0a575599b2df117c280da319f7938aaf6fdb0c04bcdbde769dbf464be69L5-R5) [[4]](diffhunk://#diff-1deee0a575599b2df117c280da319f7938aaf6fdb0c04bcdbde769dbf464be69L68-R77) [[5]](diffhunk://#diff-1deee0a575599b2df117c280da319f7938aaf6fdb0c04bcdbde769dbf464be69L100-R109) [[6]](diffhunk://#diff-1deee0a575599b2df117c280da319f7938aaf6fdb0c04bcdbde769dbf464be69L138-R146) [[7]](diffhunk://#diff-1deee0a575599b2df117c280da319f7938aaf6fdb0c04bcdbde769dbf464be69L165-R173) [[8]](diffhunk://#diff-8166a1bcbc4392033fedf604ed02a4e2d939ba8347929ba50757ab83015ddf6bL4-R9) [[9]](diffhunk://#diff-8166a1bcbc4392033fedf604ed02a4e2d939ba8347929ba50757ab83015ddf6bL21-R26) [[10]](diffhunk://#diff-c3c001eaaf6157c6ef7ac98540b1599fc600d8bb10dcc0c940fcac4423056a79R1-R4) [[11]](diffhunk://#diff-c3c001eaaf6157c6ef7ac98540b1599fc600d8bb10dcc0c940fcac4423056a79L19-R28) [[12]](diffhunk://#diff-db5ffb86bb3ad76e7c2b65ee1bb31ee907d0feed931949dbbf64bc7cc9934ff0R1-R8) [[13]](diffhunk://#diff-db5ffb86bb3ad76e7c2b65ee1bb31ee907d0feed931949dbbf64bc7cc9934ff0L30-R34) [[14]](diffhunk://#diff-7c0df19eb7c76ec29f15757f89690916623770a0e4a90c4a76a70926fbe8386bR1-R40) [[15]](diffhunk://#diff-4fd08798d3c10a63123c26eeaf62028021327a5298e972fb12ac5aa198356865L3-R3) [[16]](diffhunk://#diff-4fd08798d3c10a63123c26eeaf62028021327a5298e972fb12ac5aa198356865L13-R21) [[17]](diffhunk://#diff-4fd08798d3c10a63123c26eeaf62028021327a5298e972fb12ac5aa198356865L73-R77) [[18]](diffhunk://#diff-4fd08798d3c10a63123c26eeaf62028021327a5298e972fb12ac5aa198356865L103-R103) [[19]](diffhunk://#diff-9fcf7d403d35c8a5f4e4114eb275daef9df334c58b955dd69ff2d391a8625aedR1-R20) [[20]](diffhunk://#diff-377110fc19fe866fe4f2b416ce9be9ac274d76cf522868b9d9d08a4237900cd0R1-R22)

**Test assertion improvements:**

* Standardized file path assertions in tests to use `NodePath.relative(project.root, filePath)` for consistency and clarity, replacing custom helpers. [[1]](diffhunk://#diff-c3c001eaaf6157c6ef7ac98540b1599fc600d8bb10dcc0c940fcac4423056a79L19-R28) [[2]](diffhunk://#diff-db5ffb86bb3ad76e7c2b65ee1bb31ee907d0feed931949dbbf64bc7cc9934ff0L30-R34) [[3]](diffhunk://#diff-7c0df19eb7c76ec29f15757f89690916623770a0e4a90c4a76a70926fbe8386bR1-R40) [[4]](diffhunk://#diff-9fcf7d403d35c8a5f4e4114eb275daef9df334c58b955dd69ff2d391a8625aedR1-R20) [[5]](diffhunk://#diff-377110fc19fe866fe4f2b416ce9be9ac274d76cf522868b9d9d08a4237900cd0R1-R22)

**Stream capturing utility:**

* Improved the `captureStreams` helper in `test/helpers/streams.ts` by adding a `decodeChunk` function to robustly handle both string and `Uint8Array` inputs, ensuring accurate stream output capture in tests.

## Related issue

Closes #14 

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [x] Test improvement

## Validation

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run knip`
- [x] `npm test`
- [x] `npm run build`

## Checklist

- [x] PR targets `main`.
- [x] The change is linked to an issue, or an issue is not required.
- [x] The solution is minimal and intentional.
- [x] Tests were added or updated for behavior changes.
- [x] Documentation was updated where relevant.
