### PR TITLE
ci: split coverage into separate workflow

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -46,11 +46,3 @@ jobs:
 
       - name: Build
         run: npm run build
-
-      - name: Upload coverage
-        if: matrix.node-version == 24 && github.ref == 'refs/heads/main'
-        uses: codecov/codecov-action@v6
-        with:
-          files: ./coverage/lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,33 @@
+name: Coverage
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Test coverage
+        run: npm test
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v6
+        with:
+          files: ./coverage/lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true


### PR DESCRIPTION
## Summary

This pull request updates how code coverage is handled in the workflow by moving coverage reporting into a dedicated workflow file. The main change is to separate the coverage upload step from the general code quality checks, making the CI configuration more modular and easier to maintain.

**Workflow configuration changes:**

* Created a new workflow file, `.github/workflows/coverage.yml`, which is responsible for running tests and uploading coverage reports using Codecov when changes are pushed to the `main` branch.
* Removed the coverage upload step from the existing `.github/workflows/code-quality.yml` workflow, so it no longer handles coverage reporting.

## Related issue

Closes #12 

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Test improvement

## Validation

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run knip`
- [x] `npm test`
- [x] `npm run build`

## Checklist

- [x] PR targets `main`.
- [x] The change is linked to an issue, or an issue is not required.
- [x] The solution is minimal and intentional.
- [x] Tests were added or updated for behavior changes.
- [x] Documentation was updated where relevant.
